### PR TITLE
Replace incorrect mutex usage with atomic boolean for sessionOpen

### DIFF
--- a/realtime.go
+++ b/realtime.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"sync"
+	"sync/atomic"
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
@@ -129,8 +129,7 @@ type RealTimeClient struct {
 	conn       *websocket.Conn
 	httpClient *http.Client
 
-	mtx         sync.RWMutex
-	sessionOpen bool
+	sessionOpen atomic.Bool
 
 	// done is used to clean up resources when the client disconnects.
 	done chan bool
@@ -143,17 +142,11 @@ type RealTimeClient struct {
 }
 
 func (c *RealTimeClient) isSessionOpen() bool {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
-
-	return c.sessionOpen
+	return c.sessionOpen.Load()
 }
 
 func (c *RealTimeClient) setSessionOpen(open bool) {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
-
-	c.sessionOpen = open
+	c.sessionOpen.Store(open)
 }
 
 type RealTimeError struct {


### PR DESCRIPTION
While using this package in other places, we discovered a data race along the lines of:
```
WARNING: DATA RACE
Write at 0x00c000330190 by goroutine 44:
  github.com/AssemblyAI/assemblyai-go-sdk.(*RealTimeClient).setSessionOpen()
      [...]/vendor/github.com/AssemblyAI/assemblyai-go-sdk/realtime.go:156 +0x99
  github.com/AssemblyAI/assemblyai-go-sdk.(*RealTimeClient).Connect.func1()
      [...]/vendor/github.com/AssemblyAI/assemblyai-go-sdk/realtime.go:422 +0xb53

Previous read at 0x00c000330190 by goroutine 46:
  github.com/AssemblyAI/assemblyai-go-sdk.(*RealTimeClient).isSessionOpen()
      [...]/vendor/github.com/AssemblyAI/assemblyai-go-sdk/realtime.go:149 +0x9d
  github.com/AssemblyAI/assemblyai-go-sdk.(*RealTimeClient).Send()
      [...]/vendor/github.com/AssemblyAI/assemblyai-go-sdk/realtime.go:513 +0x6d
   [REDACTED]
```

This is because `setSessionOpen` is doing `RLock`/`RUnlock` instead of `Lock`/`Unlock` (which is a write lock).

Rather than switching the use of the mutex, I decided to just replace `sessionOpen` with an `atomic.Bool`.